### PR TITLE
bugfix: handle cpe_name field during full DB load, issue #1

### DIFF
--- a/cvedb/nvd.py
+++ b/cvedb/nvd.py
@@ -96,8 +96,10 @@ class JsonDataSource(DataSource):
             ve = node.get("versionEndIncluding", ve)
             if vs is not None or ve is not None:
                 cpe = VersionRange(cpe, start=vs, end=ve, include_start=include_start, include_end=include_end)
+            if node.get("cpe_name"):
+                raise NotImplementedError("Add support for cpe_name key with value")
             unhandled_keys = node.keys() - {"cpe23Uri", "vulnerable", "versionStartIncluding", "versionStartExcluding",
-                                            "versionEndIncluding", "versionEndExcluding"}
+                                            "versionEndIncluding", "versionEndExcluding", "cpe_name"}
             if unhandled_keys:
                 raise NotImplementedError(f"Add support for CPE 23 URI node keys {unhandled_keys!r}")
             return cpe


### PR DESCRIPTION
The "cpe_name" field seems to always be empty in the feed files, so we can just verify they are empty and continue as usual, and if they are not empty then raise an exception.